### PR TITLE
ci: run pytest during rpm building

### DIFF
--- a/.github/actions/buildrpm/Dockerfile
+++ b/.github/actions/buildrpm/Dockerfile
@@ -6,15 +6,14 @@ RUN zypper patch -y
 # Install necessary packages
 RUN zypper in -y \
     rpm-build rpmdevtools dnf-plugins-core python3 git gcc fdupes \
-    python311-pip python311-setuptools python311-setuptools_scm python311-wheel \
-    python312-pip python312-setuptools python312-setuptools_scm python312-wheel \
-    python313-pip python313-setuptools python313-setuptools_scm python313-wheel
+    python311-pip python311-setuptools python311-setuptools_scm python311-wheel python311-pytest \
+    python312-pip python312-setuptools python312-setuptools_scm python312-wheel python312-pytest \
+    python313-pip python313-setuptools python313-setuptools_scm python313-wheel python313-pytest
 
 WORKDIR /usr/src/packages
 
 # Copy necessary files to build a rpm package
 COPY python-bytecode.spec SPECS/
-COPY python-bytecode.tar.gz SOURCES/
 
 # Set up the entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/actions/buildrpm/entrypoint.sh
+++ b/.github/actions/buildrpm/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 cd /usr/src/packages
 
+# $GITHUB_SERVER_URL (https://github.com)
+# $GITHUB_REPOSITORY (mrcaique/bytecode)
+git clone "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+tar -czf SOURCES/python-bytecode.tar.gz bytecode
+
 # Update release verion on spec file
 sed -i -e "s/##RPMVERSION##/$RELEASE_VERSION/" SPECS/python-bytecode.spec
 

--- a/.github/actions/buildrpm/python-bytecode.spec
+++ b/.github/actions/buildrpm/python-bytecode.spec
@@ -45,6 +45,9 @@ Python module to generate and modify bytecode
 %pyproject_install
 %python_expand %fdupes %{buildroot}%{$python_sitelib}
 
+%check
+%pytest
+
 %files %{python_files}
 %doc README.rst
 %license COPYING

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -15,14 +15,7 @@ jobs:
       - name: Set release version env
         run: echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
 
-      - name: Create source archive
-        run: >
-          cd .. 
-          && tar -czf python-bytecode.tar.gz bytecode
-          && mv python-bytecode.tar.gz bytecode/.github/actions/buildrpm
-
       - name: Build RPM package
-        id: rpm
         uses: ./.github/actions/buildrpm
 
       - name: Upload RPM as artifact


### PR DESCRIPTION
* Update Dockerfile to include necessary packages;
* Added related flags on the spec file;
* Clone the directory inside the container instead of copying a tarball. This fixes an issue where the repo always are shallow-cloned to container, making setuptools-scm could not infer the version and generating version based on the latest commit, thus, breaking the tests.